### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/shyampatrick/2ec8e0f2-adf9-4efe-b9d3-46a1a7400e24/313e2026-f131-4b9a-b603-199f9a59146a/_apis/work/boardbadge/0229fd3c-3130-4e7e-8b57-d33167388148)](https://dev.azure.com/shyampatrick/2ec8e0f2-adf9-4efe-b9d3-46a1a7400e24/_boards/board/t/313e2026-f131-4b9a-b603-199f9a59146a/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#216](https://dev.azure.com/shyampatrick/2ec8e0f2-adf9-4efe-b9d3-46a1a7400e24/_workitems/edit/216). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.